### PR TITLE
正規表現完了（仮）

### DIFF
--- a/app/models/phone.rb
+++ b/app/models/phone.rb
@@ -1,4 +1,4 @@
 class Phone < ApplicationRecord
   belongs_to :user, optional: true
-  validates :phonenumber,presence: true
+  validates :phonenumber,presence: true, format: { with: /\A\d{10,11}\z/}
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,20 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  validates :nickname, :first_name, :last_name, :first_name_kana, :last_name_kana, :year, :month, :day, presence: true
+  with_options presence: true do
+    validates :nickname, length: { maximum: 10 }
+    with_options format: {with: /\A(?:\p{Hiragana}|\p{Katakana}|[ー－]|[一-龠々])+\z/} do
+      validates :first_name
+      validates :last_name
+    end
+    with_options format: {with: /\A[ァ-ヶー－]+\z/} do
+      validates :first_name_kana
+      validates :last_name_kana
+    end
+    validates :year
+    validates :month
+    validates :day
+  end
+
   has_one :phone
 end


### PR DESCRIPTION
what
登録の際
ニックネームは１０文字まで
カナ文字の振り仮名はカナ文字のみ
電話番号は半角数字10、11桁のみ登録できるようにした。
why
電話番号なのに文字も何桁でもいけるのは情報としての精度が悪いため。
振り仮名（カナ）も同じく

以下画像
https://gyazo.com/ba0ccd456d0478e54f67e4d5d208495b
https://gyazo.com/1d6468517bde54ae5cef6c82a79af576