### PR TITLE
商品詳細表示サーバーサイド完成（仮）

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,6 +8,8 @@ class ItemsController < ApplicationController
   
   def show
     @item = Item.find(params[:id])
+    @category = Category.find(@item.category_id)
+    @user = User.find(@item.seller_id)
   end
   
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,7 @@ class ItemsController < ApplicationController
   end
   
   def show
+    @item = Item.find(params[:id])
   end
   
   def new

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,6 +1,7 @@
 .main-contents
   .show-item-wrapper
-    %h1 テストタイトル
+    %h1
+      = @item.name
     .show-contents
       .images
         = image_tag "ifon.png", class: "images__main"
@@ -15,7 +16,7 @@
           %th 
             出品者
           %td
-            テスト
+            =@user.nickname
             %br
             %i.fas.fa-smile-beam
             %span 11
@@ -27,40 +28,39 @@
           %th 
             カテゴリー
           %td
-            テスト
+            =@category.parent.parent.name
+            %br
+            =@category.parent.name
+            %br
+            =@category.name
         %tr
           %th 
             ブランド
           %td
-            テスト
+            =@item.brand
         %tr
           %th 
             商品の状態
           %td
-            テスト
+            =@item.condition
         %tr
           %th 
             配送料の負担
           %td
-            テスト
-        %tr
-          %th 
-            配送の方法
-          %td
-            テスト
+            =@item.postage
         %tr
           %th 
             発送元地域
           %td
-            テスト
+            =@item.prefecture.name
         %tr
           %th 
             発送日の目安
           %td
-            テスト
+            =@item.shipment_day
     .show-item-price
       %h1
-        ¥7,000
+        = @item.price
       %span.show-item-price__tax
         (税込)
       %span.show-item-price__sent
@@ -72,7 +72,7 @@
       = link_to "" do
         購入画面に進む
     %p.show-item-description
-      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      =@item.description
     .show-item-btns
       .show-item-btns__like
         %i.fas.fa-heart


### PR DESCRIPTION
what
商品詳細ページを商品ごとに表示
商品詳細ページに商品ごとの情報表示(出品者,カテゴリー,値段など)

why
商品を購入する際に必ず遷移するべきページ
詳細ページを見ないと買い手も安心できない可能性がある。

item/1
https://gyazo.com/580c76b84ac25b6e87f1d8ba8bf19a42
item/2
https://gyazo.com/f1d70776da98aab20bde789646d0a5f0