### PR TITLE
buy_checkのルーティングが消えてた事件解決

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,9 +8,9 @@ Rails.application.routes.draw do
   get '/conform_card/:user_id' => 'users#conform_card', as: 'conform_card'
   get '/edit_profile/:user_id' => 'users#edit_profile', as: 'edit_profile'
   get '/mypage/:user_id' => 'users#mypage', as: 'mypage'
+  get '/buy_check/:user_id' => 'items#buy_check', as: 'buy_check'
 
-
-  resources :items, only:[:show,:new, :create,:buy_check] do
+  resources :items, only:[:show,:new, :create] do
     collection do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }


### PR DESCRIPTION
what
buy_checkのルーティングを追加
/buy_check/:user_id(.:format)

why
ビュー画面は作られていたのでルーティングを追加した。