### PR TITLE
ロゴマークからホームページへ、一覧から詳細ページへそのほか細かい部分修正

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -13,15 +13,17 @@
       - @categories.each do |category|
         %h2 
           #{category.name}新着アイテム
+        %br/
         = link_to "" do
           もっと見る
           %i.fa.fa-chevron-righ
         - Item.where(category_id: category.subtree).each do |item|
           .prodacuts__cards
             .prodacuts__cards-item
-              .prodacuts__cards-content
-                = image_tag item.images.first.src.url
-              .prodacuts__cards-name
-                = item.name
-              .prodacuts__card-price
-                = "#{item.price}円"
+              = link_to item_path(item) do
+                .prodacuts__cards-content
+                  = image_tag item.images.first.src.url
+                .prodacuts__cards-name
+                  = item.name
+                .prodacuts__card-price
+                  = "#{item.price}円"

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,7 +1,8 @@
 .new_header
 .new_header__top
  .new_header__logo
- = image_tag "logo-acdd90ac4f472d5a6f7a330d33ab1225.svg",size:"189x128"
+ = link_to "/" do
+  = image_tag "logo-acdd90ac4f472d5a6f7a330d33ab1225.svg",size:"189x128"
 
  = render 'form'
 

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -2,7 +2,7 @@
   .contents
     .contents__top
       .contents__top-logo
-        = link_to "" do
+        = link_to "/" do
           = image_tag "logo.png"
       %form
         %input{:name => "NAME", :placeholder => "何かお探しですか？", :type => "text"}/
@@ -82,7 +82,6 @@
           = link_to mypage_path(current_user.id), class:"contents__bottom-signs-ok" do
             = image_tag "apple.png"
             %span マイページ
-          = link_to "ログアウト", destroy_user_session_path, method: :delete
         - else
           = link_to "新規会員登録", registration_selection_path, class:"contents__bottom-signs-up"
           = link_to "ログイン", new_user_session_path, class:"contents__bottom-signs-in"


### PR DESCRIPTION
what
ロゴからホームページにとぶ
一覧の商品から商品の詳細ページへとぶ
一覧ページのレディース新着アイテムメンズ新着アイテムビュー画面でつながっていたので分けた
why
ホームページへ飛ぶ手段がないから
一覧から詳細に飛べないと、買うこともできないから
見た目が悪いから